### PR TITLE
fix: incorrect shown branch name

### DIFF
--- a/relay.php
+++ b/relay.php
@@ -68,7 +68,7 @@ if (isset($_POST["payload"])) {
     // Grab repository info
     if (count($dc_hiddenreps) == 0 || !in_array($aPayload["repository"]["name"], $dc_hiddenreps)) {
         $sRepository = "[" . $aPayload["repository"]["name"];
-        $sRepository .= ":" . $aPayload["repository"]["default_branch"] . "]";
+        $sRepository .= ":" . str_replace("refs/head/", "", $aPayload["ref"]) . "]";
         $sRepository .= " " . count($aCommits) . " new commit" . (count($aCommits) <= 1 ? "" : "s");
         $sRepositoryUrl = $aPayload["repository"]["url"];
     } else {


### PR DESCRIPTION
Should fix an issue raised by Lythium: 
![image](https://github.com/dotCore-off/github-webhook-relay/assets/64563384/00f5ae13-07e7-43d8-b27f-1a26b6ebe160)
